### PR TITLE
Fix exit code so fails if errors found

### DIFF
--- a/test/image-checker.py
+++ b/test/image-checker.py
@@ -186,6 +186,6 @@ if __name__ == "__main__":
     print("Found {} total errors and {} total warnings".format(
         len(all_errors), len(all_warnings)))
 
-    sys.exit(len(errors))
+    sys.exit(len(all_errors))
 
 # End of file


### PR DESCRIPTION
This should fail on the CI:
```
Found 5 total errors and 585 total warnings
The command "python test/image-checker.py --resize "packs/*.yaml"" exited with 5.
```